### PR TITLE
Minor fix to autograd

### DIFF
--- a/code/autograd/finite_diff.R
+++ b/code/autograd/finite_diff.R
@@ -60,5 +60,5 @@ all.equal(y[2], g(x[1]))
 error = g(x[1]) - y[2]
 options(digits=16)
 print(error)
-f(x[1]) == y[2]  ## warning: too demanding??
+g(x[1]) == y[2]  ## Though demanding, the error here is small enough to neglect
 


### PR DESCRIPTION
Hello Stephen,

If I understand this correctly, it seems that the last line of the `autograd` codes mistakenly compared the derivative part of the dual number to f(x) instead of f'(x), the derivative. In fact, as we can see through line #62, the error between `y[2]` and `g(x[1])` is smaller than 1e-16, thus the two amounts should be considered equal, i.e. ==, by R.

Yujia